### PR TITLE
브랜드 조회,검색 기능 구현

### DIFF
--- a/src/main/java/com/shoppingmall/project_shoppingmall/constant/BrandSearchType.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/constant/BrandSearchType.java
@@ -1,0 +1,18 @@
+package com.shoppingmall.project_shoppingmall.constant;
+
+import lombok.*;
+
+public enum BrandSearchType {
+    BRAND_NM("브랜드명"),
+    BRAND_CODE("브랜드코드");
+
+    @Getter
+    private String description;
+
+    BrandSearchType(String description) {
+
+        this.description = description;
+    }
+
+
+}

--- a/src/main/java/com/shoppingmall/project_shoppingmall/controller/BrandController.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/controller/BrandController.java
@@ -6,11 +6,14 @@ import com.shoppingmall.project_shoppingmall.dto.*;
 import com.shoppingmall.project_shoppingmall.service.*;
 import lombok.*;
 import org.springframework.beans.factory.annotation.*;
+import org.springframework.data.domain.*;
+import org.springframework.data.web.*;
 import org.springframework.stereotype.*;
 import org.springframework.ui.*;
 import org.springframework.validation.*;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.*;
 import javax.servlet.http.*;
 import javax.validation.*;
 import java.util.*;
@@ -21,17 +24,16 @@ import java.util.stream.*;
 public class BrandController {
 
     private final BrandService brandService;
+    private final PaginationService paginationService;
 
     @ModelAttribute("brandStatus")
     public BrandStatus[] brandStatuses(){
         return BrandStatus.values();
     }
 
-    @ModelAttribute("brands")
-    public List<Brand> brandList() {
-        return brandService.findAll();
-    }
-
+//    @ModelAttribute("brands")
+//    public Page<Brand> brandList(Pageable pageable) { return brandService.findAll(pageable);
+//    }
 
     @GetMapping("/admin/brand/brandadd")
     public String brandForm(@ModelAttribute("brandFormDto") BrandFormDto brandFormDto){
@@ -42,7 +44,6 @@ public class BrandController {
     @PostMapping("/admin/brand/brandadd")
     public String savebrand(@Valid BrandFormDto brandFormDto ,
                             BindingResult bindingResult, Model model){
-
         if(bindingResult.hasErrors()){
 
             return "brand/brandForm";
@@ -50,24 +51,43 @@ public class BrandController {
 
         try {
             brandService.saveBrand(brandFormDto);
-
             model.addAttribute("message", "브랜드가 등록되었습니다.");
             return "redirect:/admin/brand/management";
-
 
         } catch (Exception e){
             model.addAttribute("errorMessage", "브렌드 등록에 실패했습니다.");
             return "brand/brandForm";
         }
-//        return "brand/brandForm";
+
     }
 
     @GetMapping(value = "/admin/brand/management")
-    public String brandmanage(Model model){
-        model.addAttribute("brandFormDto",new BrandFormDto());
+    public String brandmanage(@RequestParam(required = false) BrandSearchType brandSearchType,
+                              @RequestParam(required = false) String searchValue,
+                              @RequestParam(required = false) String searchStatus,
+                              @PageableDefault(page = 0,size = 10) Pageable pageable,
+                              Model model){
+
+        Page<Brand> searchBrands = brandService.searchBrands(brandSearchType,searchValue,searchStatus,pageable).map(BrandFormDto::toBrand);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(),searchBrands.getTotalPages());
+
+
+        model.addAttribute("paginationBarNumbers", barNumbers);
+        model.addAttribute("BrandSearchType",brandSearchType.values());
         model.addAttribute("IdsTransferDto",new IdsTransferDto());  // retrun list
+        model.addAttribute("searchBrands",searchBrands);
         return "brand/brandForm";
     }
+
+//    @GetMapping(value = "/admin/brand/management/{brandId}")
+//    public String brand(@PathVariable Long brandId,Model model){
+//        Brand brand = brandService.getBrand(brandId);
+//        model.addAttribute("brand",brand);
+//
+//
+//    return "brand/brandAdd";
+//    }
+
 
     @PostMapping("/admin/brand/deleteBrands")
     public String deleteBrands(IdsTransferDto idsTransferDto){

--- a/src/main/java/com/shoppingmall/project_shoppingmall/controller/BrandController.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/controller/BrandController.java
@@ -13,6 +13,7 @@ import org.springframework.ui.*;
 import org.springframework.validation.*;
 import org.springframework.web.bind.annotation.*;
 
+
 import javax.servlet.*;
 import javax.servlet.http.*;
 import javax.validation.*;
@@ -65,17 +66,19 @@ public class BrandController {
     public String brandmanage(@RequestParam(required = false) BrandSearchType brandSearchType,
                               @RequestParam(required = false) String searchValue,
                               @RequestParam(required = false) String searchStatus,
-                              @PageableDefault(page = 0,size = 10) Pageable pageable,
+                              @PageableDefault(page = 0,size = 10 ,sort = "brandCode" ,direction = Sort.Direction.DESC) Pageable pageable,
                               Model model){
 
         Page<Brand> searchBrands = brandService.searchBrands(brandSearchType,searchValue,searchStatus,pageable).map(BrandFormDto::toBrand);
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(),searchBrands.getTotalPages());
 
 
+
         model.addAttribute("paginationBarNumbers", barNumbers);
         model.addAttribute("BrandSearchType",brandSearchType.values());
         model.addAttribute("IdsTransferDto",new IdsTransferDto());  // retrun list
         model.addAttribute("searchBrands",searchBrands);
+
         return "brand/brandForm";
     }
 

--- a/src/main/java/com/shoppingmall/project_shoppingmall/domain/Brand.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/domain/Brand.java
@@ -24,16 +24,14 @@ public class Brand extends BaseEntity{
     @Column(name = "brand_status")
     private boolean brandStatus;
 
-//    public Brand(Long id, String brandNm, boolean isActive) {
-//        this.id = id;
-//        this.brandNm = brandNm;
-//        this.isActive = isActive;
-//    }
+    @Column(name = "brand_code")
+    private String brandCode;
 
     public void updateBrand(BrandFormDto brandFormDto){
         this.id = brandFormDto.getId();
         this.brandNm = brandFormDto.getBrandNm();
         this.brandStatus = brandFormDto.isBrandStatus();
+        this.brandCode = brandFormDto.getBrandCode();
     }
 
 }

--- a/src/main/java/com/shoppingmall/project_shoppingmall/dto/BrandFormDto.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/dto/BrandFormDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.*;
 import java.util.*;
 
 @Getter @Setter
-public class BrandFormDto {
+public class BrandFormDto extends BaseEntity{
 
     private Long id;
 

--- a/src/main/java/com/shoppingmall/project_shoppingmall/dto/BrandFormDto.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/dto/BrandFormDto.java
@@ -17,6 +17,8 @@ public class BrandFormDto {
 
     private boolean brandStatus;
 
+    private String brandCode;
+
     public Brand toBrand(){
         ModelMapper modelMapper = new ModelMapper();
         return modelMapper.map(this, Brand.class);

--- a/src/main/java/com/shoppingmall/project_shoppingmall/repository/BrandRepository.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/repository/BrandRepository.java
@@ -1,6 +1,8 @@
 package com.shoppingmall.project_shoppingmall.repository;
 
 import com.shoppingmall.project_shoppingmall.domain.*;
+import com.shoppingmall.project_shoppingmall.dto.*;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.querydsl.*;
 
@@ -9,6 +11,13 @@ import java.util.*;
 public interface BrandRepository extends JpaRepository<Brand,Long> ,
         QuerydslPredicateExecutor<Brand>,BrandRepositoryCustom {
 
-    List<Brand> findByBrandNm(String brandNm);
+        Page<Brand> findByBrandNmContaining(String title, Pageable pageable);
+        Page<Brand> findByBrandCodeContaining(String content, Pageable pageable);
+
+        Page<Brand> findByBrandNmContainingAndBrandStatusIsTrue(String title, Pageable pageable);
+        Page<Brand> findByBrandNmContainingAndBrandStatusIsFalse(String title, Pageable pageable);
+
+        Page<Brand> findByBrandCodeContainingAndBrandStatusIsTrue(String content, Pageable pageable);
+        Page<Brand> findByBrandCodeContainingAndBrandStatusIsFalse(String content, Pageable pageable);
 
 }

--- a/src/main/java/com/shoppingmall/project_shoppingmall/service/PaginationService.java
+++ b/src/main/java/com/shoppingmall/project_shoppingmall/service/PaginationService.java
@@ -1,0 +1,23 @@
+package com.shoppingmall.project_shoppingmall.service;
+
+import org.springframework.stereotype.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+@Service
+public class PaginationService {
+
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int totalPages) {
+        int startNumber = Math.max(currentPageNumber - (BAR_LENGTH / 2), 0);
+        int endNumber = Math.min(startNumber + BAR_LENGTH, totalPages);
+
+        return IntStream.range(startNumber, endNumber).boxed().collect(Collectors.toList());
+    }
+
+    public int currentBarLength() {
+        return BAR_LENGTH;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ management.endpoints.web.exposure.include: "*"
 server.port: 9091
 
 #나중에 제거해야함
-server.servlet.session.timeout: 1800
+server.servlet.session.timeout: 180000
 
 
 spring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,8 @@ management.endpoints.web.exposure.include: "*"
 
 server.port: 9091
 
+#나중에 제거해야함
+server.servlet.session.timeout: 1800
 
 
 spring:
@@ -13,7 +15,7 @@ spring:
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
-    hibernate.ddl-auto: create
+    hibernate.ddl-auto: validate
     show-sql: true
     properties:
       hibernate.format_sql: true

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO member (name, email, password, address, role)
-VALUES ('John Doe', 'admin@example.com', '$2a$12$NiP8ZlFx6bcXIvXwWy0BtOEu2ZWbg4IfHGaUJhB6d.Epygv5Xba5q', '123 Main St', 'ADMIN');
-INSERT INTO member (name, email, password, address, role)
-VALUES ('User', 'user@example.com', '$2a$12$NiP8ZlFx6bcXIvXwWy0BtOEu2ZWbg4IfHGaUJhB6d.Epygv5Xba5q', '123 Main St', 'USER');
+# INSERT INTO member (name, email, password, address, role)
+# VALUES ('John Doe', 'admin@example.com', '$2a$12$NiP8ZlFx6bcXIvXwWy0BtOEu2ZWbg4IfHGaUJhB6d.Epygv5Xba5q', '123 Main St', 'ADMIN');
+# INSERT INTO member (name, email, password, address, role)
+# VALUES ('User', 'user@example.com', '$2a$12$NiP8ZlFx6bcXIvXwWy0BtOEu2ZWbg4IfHGaUJhB6d.Epygv5Xba5q', '123 Main St', 'USER');

--- a/src/main/resources/static/css/management.css
+++ b/src/main/resources/static/css/management.css
@@ -389,7 +389,7 @@ strong {
     font-weight: bold;
 }
 
-.mBoard .array button {
+.mBoard .array a {
     overflow: hidden;
     display: inline-block;
     width: 7px;

--- a/src/main/resources/templates/brand/BrandForm.html
+++ b/src/main/resources/templates/brand/BrandForm.html
@@ -6,6 +6,26 @@
 <th:block layout:fragment="script">
 
     <script th:inline="javascript">
+        function countTableRows() {
+            const tbodySelector = 'tbody.center';
+
+            // 테이블 바디 요소 가져오기
+            const tableBody = document.querySelector(tbodySelector);
+
+            // 테이블 바디 내의 테이블 행 (<tr> 요소) 개수 계산
+            const rowCount = tableBody.querySelectorAll('tr').length;
+
+            const countElement = document.querySelector('.total strong');
+            countElement.textContent = rowCount;
+
+        }
+
+        window.addEventListener('load', function() {
+            countTableRows();
+            console.log(`테이블 행 개수: ${rowCount}`);
+
+        });
+
 
         function updateSelectedLabel(e) {
             // 현재 선택된 라벨 찾기
@@ -59,38 +79,6 @@
 
         }
 
-        // 쓰이지 않아서 주석처리 후에 삭제함.
-        // function updateSelectedBrandIds() {
-        //     const checkedBoxes = document.querySelectorAll('.rowChk:checked');
-        //     let brandIds = [];
-        //
-        //     // Build an array of selected brand IDs
-        //     for (const checkbox of checkedBoxes) {
-        //         brandIds.push(parseInt(checkbox.value, 10));
-        //
-        //     }
-        //     console.log(brandIds);
-        //
-        //     if (brandIds.length == 0) {
-        //         alert("삭제할 브랜드를 선택해주세요")
-        //         return false;
-        //     }
-        //
-        //
-        //     if (brandIds === null) {
-        //         console.error('brandIds element is null');
-        //         return;
-        //     }
-        //
-        //     // 폼 전송
-        //     alert("선택한 브랜드가 삭제 되었습니다.")
-        //     const TransferidList = document.getElementById('transferbrandIds2');
-        //     TransferidList.value = brandIds;
-        //
-        //     return true;
-        // }
-
-
     </script>
 </th:block>
 
@@ -104,26 +92,32 @@
         </div>
         <div class="section" id="QA_list1">
             <div class="mBoard gSmall">
-
+                <form id="search-form" th:action ="@{/admin/brand/management}" th:method="get">
                     <table border="1" summary="">
                         <caption>브랜드 검색</caption>
                         <tbody>
                         <tr>
                             <th scope="row">브랜드 검색</th>
+
                             <td>
-                                <select class="fSelect" id="eSearchKey" style="width:100px;">
-                                    <option value="brand_name">브랜드명</option>
-                                    <option value="brand_code">브랜드코드</option>
+
+                                <select class="fSelect" th:name="brandSearchType" id="brandSearchType" style="width:100px;">
+                                    <option th:each="B_Type : ${BrandSearchType}"
+                                            th:value="${B_Type}"
+                                            th:text="${B_Type.getDescription()}"
+                                            >
+                                    </option>
                                 </select>
-                                <input type="text" class="fText" id="eSearchValue" value="" style="width:400px;" fw-label="검색" fw-filter="isMaxByte[200]">
+                                <input type="text" class="fText" name="searchValue"  id="SearchValue" th:value="${param.searchValue}" style="width:400px;" fw-label="검색" fw-filter="isMaxByte[200]">
                             </td>
+
                         </tr>
                         <tr>
                             <th scope="row">사용여부</th>
                             <td>
-                                <label class="gLabel eSelected"><input type="radio" name="use_brand" value="A" class="fChk" checked="checked"> 전체</label>
-                                <label class="gLabel"><input type="radio" name="use_brand" value="T" class="fChk"> 사용함</label>
-                                <label class="gLabel"><input type="radio" name="use_brand" value="F" class="fChk"> 사용안함</label>
+                                <label class="gLabel eSelected"><input type="radio" name="searchStatus" th:value="A" class="fChk" checked="checked"> 전체</label>
+                                <label class="gLabel"><input type="radio" name="searchStatus" th:value="T" class="fChk"> 사용함</label>
+                                <label class="gLabel"><input type="radio" name="searchStatus" th:value="F" class="fChk"> 사용안함</label>
                             </td>
                         </tr>
                         </tbody>
@@ -131,8 +125,9 @@
 
             </div>
             <div class="mButton gCenter">
-                <a href="#none" class="btnSearch" id="eSearch"><span>검색</span></a>
+                <button type="submit" class="btnSearch" id="eSearch"><span>검색</span></button>
             </div>
+            </form>
         </div>
         <div class="section" id="QA_list2">
             <div class="mTitle">
@@ -140,7 +135,7 @@
             </div>
             <div class="mState">
                 <div class="gLeft">
-                    <p class="total">[총 <strong>1</strong>개]</p>
+                    <p class="total">[총 <strong text="${rowCount}"></strong>개]</p>
                 </div>
                 <div class="gRight">
                     <select class="fSelect" id="eListLimitCount">
@@ -152,6 +147,7 @@
                     </select>
                 </div>
             </div>
+            <form method="post" enctype="multipart/form-data" th:action="@{/admin/brand/deleteBrands}" th:object="${IdsTransferDto}">
             <div class="mCtrl typeHeader">
                 <div class="gLeft">
                     <button class="btnNormal eDelete" style="padding: 0;border-color: transparent " type="submit" ><span><em class="icoDel"></em> 삭제</span></button>
@@ -192,15 +188,15 @@
 
 
                     <tbody class="center">
-                    <form method="post" enctype="multipart/form-data" th:action="@{/admin/brand/deleteBrands}" th:object="${IdsTransferDto}">
-                    <th:block th:each="brand : ${brands}" class="">
+
+                    <th:block th:each="brand : ${searchBrands.content}" class="">
                     <tr>
                         <td>
                             <input type="checkbox" name="selectedBrandIds" th:value="${brand.id}" class="rowChk" >
                         </td>
                         <td><th:block th:text="${brand.id}">1</th:block></td>
-                        <td class="txtCode"><a href="" class="txtLink">B0000000</a></td>
-                        <td class="left"><a href="#" class="txtLink" th:text="${brand.brandNm}">자체브랜드</a></td>
+                        <td class="txtCode"><a th:href="@{/admin/brand/management/${brand.id}}" class="txtLink" th:text="${brand.brandCode}" >B0000000</a></td>
+                        <td class="left"><a th:href="@{/admin/brand/management/${brand.id}}" class="txtLink" th:text="${brand.brandNm}">자체브랜드</a></td>
                         <td th:text="${brand.brandStatus}">사용함</td>
                         <td>2024-02-15</td>
                         <td class="right"><a href="" target="_blank" title="새창 열림" class="txtLink eShowChild">2</a></td>
@@ -224,10 +220,17 @@
                     <a class="btnCtrl" href="/admin/brand/brandadd"><span>브랜드 등록</span></a>
                 </div>
             </div>
+
             <div class="mPaginate">
-                <ol>
-                    <li><strong title="현재페이지">1</strong></li>
-                    <li><a href="">2</a>   </li>
+                <ol th:each="pageNumber : ${paginationBarNumbers}">
+                    <li >
+                        <a
+                           th:href="@{/admin/brand/management(searchType=${param.searchType} ,searchValue=${param.searchValue},page=${pageNumber}  )}">
+                            <strong th:if="${pageNumber} == ${searchBrands.number}" th:text = "${pageNumber + 1}"></strong>
+                            <span th:if="${pageNumber} != ${searchBrands.number}" th:text = "${pageNumber + 1}"></span>
+                        </a>
+                    </li>
+
                 </ol>
             </div>
 

--- a/src/main/resources/templates/brand/BrandForm.html
+++ b/src/main/resources/templates/brand/BrandForm.html
@@ -135,12 +135,11 @@
                         </tr>
                         </tbody>
                     </table>
-
-            </div>
+                </div>
             <div class="mButton gCenter">
                 <button type="submit" class="btnSearch" id="eSearch"><span>검색</span></button>
             </div>
-            </form>
+                    </form>
         </div>
         <div class="section" id="QA_list2">
             <div class="mTitle">
@@ -151,13 +150,13 @@
                     <p class="total">[총 <strong text="${rowCount}"></strong>개]</p>
                 </div>
                 <div class="gRight">
-                    <select class="fSelect" id="eListLimitCount">
-                        <option value="10">10개씩보기</option>
-                        <option value="20" selected="selected">20개씩보기</option>
-                        <option value="30">30개씩보기</option>
-                        <option value="50">50개씩보기</option>
-                        <option value="100">100개씩보기</option>
-                    </select>
+<!--                    <select class="fSelect" id="eListLimitCount">-->
+<!--                        <option value="10">10개씩보기</option>-->
+<!--                        <option value="20" selected="selected">20개씩보기</option>-->
+<!--                        <option value="30">30개씩보기</option>-->
+<!--                        <option value="50">50개씩보기</option>-->
+<!--                        <option value="100">100개씩보기</option>-->
+<!--                    </select>-->
                 </div>
             </div>
             <form method="post" enctype="multipart/form-data" th:action="@{/admin/brand/deleteBrands}" th:object="${IdsTransferDto}">
@@ -184,16 +183,24 @@
                         <col style="width:100px">
                     </colgroup>
                     <thead>
+
                     <tr>
                         <th scope="col"><input type="checkbox" id="allCheckBox" onclick="allChecked()"></th>
                         <th scope="col">No</th>
                         <th scope="col">브랜드코드</th>
                         <th scope="col">
-                            <strong class="array " id="eBrandName">브랜드명<button type="button">오름차순 정렬</button></strong>
+                            <strong class="array " id="eBrandName">브랜드명
+                                <a type="button" th:href="@{/admin/brand/management(brandSearchType=${param.brandSearchType},
+                                searchValue=${param.searchValue},
+                                searchStatus=${param.searchStatus},
+                                page=${pageNumber},
+                                sort='BrandNm')
+                                }">내림차순 정렬</a> </strong>
+
                         </th>
                         <th scope="col">사용여부</th>
                         <th scope="col">
-                            <strong class="array descend" id="eBrandInsert">등록일자<button type="button">오름차순 정렬</button></strong>
+                            <strong class="array descend" id="eBrandInsert">등록일자</strong>
                         </th>
                         <th scope="col">상품수</th>
                     </tr>
@@ -211,7 +218,7 @@
                         <td class="txtCode"><a th:href="@{/admin/brand/management/${brand.id}}" class="txtLink" th:text="${brand.brandCode}" >B0000000</a></td>
                         <td class="left"><a th:href="@{/admin/brand/management/${brand.id}}" class="txtLink" th:text="${brand.brandNm}">자체브랜드</a></td>
                         <td th:text="${brand.brandStatus}">사용함</td>
-                        <td>2024-02-15</td>
+                        <td th:text="${#temporals.format(brand.regTime,'yyyy-MM-dd')}"> 2024-02-15</td>
                         <td class="right"><a href="" target="_blank" title="새창 열림" class="txtLink eShowChild">2</a></td>
                     </tr>
                     </th:block>
@@ -224,7 +231,7 @@
 
 
 
-                    <button class="btnNormal eDelete" type="submit" style="padding: 0;border-color: transparent " ><span><em class="icoDel"></em> 삭제</span></button>
+                    <button class="btnNormal eDelete" type="submit" style="padding: 0;border-color: transparent " onclick="return validateSelectedBrands()" ><span><em class="icoDel"></em> 삭제</span></button>
                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                     </form>
 
@@ -238,7 +245,7 @@
                 <ol th:each="pageNumber : ${paginationBarNumbers}">
                     <li >
                         <a
-                           th:href="@{/admin/brand/management(searchType=${param.searchType} ,searchValue=${param.searchValue},page=${pageNumber}  )}">
+                           th:href="@{/admin/brand/management(brandSearchType=${param.brandSearchType} ,searchValue=${param.searchValue},searchStatus=${param.searchStatus} ,page=${pageNumber}  )}">
                             <strong th:if="${pageNumber} == ${searchBrands.number}" th:text = "${pageNumber + 1}"></strong>
                             <span th:if="${pageNumber} != ${searchBrands.number}" th:text = "${pageNumber + 1}"></span>
                         </a>
@@ -249,4 +256,5 @@
 
         </div>
 </div>
+
 </html>

--- a/src/main/resources/templates/brand/BrandForm.html
+++ b/src/main/resources/templates/brand/BrandForm.html
@@ -150,13 +150,7 @@
                     <p class="total">[총 <strong text="${rowCount}"></strong>개]</p>
                 </div>
                 <div class="gRight">
-<!--                    <select class="fSelect" id="eListLimitCount">-->
-<!--                        <option value="10">10개씩보기</option>-->
-<!--                        <option value="20" selected="selected">20개씩보기</option>-->
-<!--                        <option value="30">30개씩보기</option>-->
-<!--                        <option value="50">50개씩보기</option>-->
-<!--                        <option value="100">100개씩보기</option>-->
-<!--                    </select>-->
+
                 </div>
             </div>
             <form method="post" enctype="multipart/form-data" th:action="@{/admin/brand/deleteBrands}" th:object="${IdsTransferDto}">

--- a/src/main/resources/templates/brand/BrandForm.html
+++ b/src/main/resources/templates/brand/BrandForm.html
@@ -6,6 +6,19 @@
 <th:block layout:fragment="script">
 
     <script th:inline="javascript">
+        function validateSelectedBrands() {
+            // 선택된 checkbox 개수를 가져옵니다.
+            const selectedBrands = document.querySelectorAll('input[name="selectedBrandIds"]:checked');
+
+            // 선택된 브랜드가 없으면 에러 메시지를 출력하고 submit을 막습니다.
+            if (selectedBrands.length === 0) {
+                alert("삭제할 브랜드를 선택하세요.");
+                return false;
+            }
+
+            // 선택된 브랜드가 있다면 정상적으로 submit을 진행합니다.
+            return true;
+        }
         function countTableRows() {
             const tbodySelector = 'tbody.center';
 
@@ -150,7 +163,7 @@
             <form method="post" enctype="multipart/form-data" th:action="@{/admin/brand/deleteBrands}" th:object="${IdsTransferDto}">
             <div class="mCtrl typeHeader">
                 <div class="gLeft">
-                    <button class="btnNormal eDelete" style="padding: 0;border-color: transparent " type="submit" ><span><em class="icoDel"></em> 삭제</span></button>
+                    <button class="btnNormal eDelete" style="padding: 0;border-color: transparent " onclick="return validateSelectedBrands()" type="submit" ><span><em class="icoDel"></em> 삭제</span></button>
                 </div>
                 <div class="gRight">
                     <a class="btnCtrl" href="/admin/brand/brandadd"><span>브랜드 등록</span></a>

--- a/src/test/java/com/shoppingmall/project_shoppingmall/repository/BrandRepositoryTest.java
+++ b/src/test/java/com/shoppingmall/project_shoppingmall/repository/BrandRepositoryTest.java
@@ -23,7 +23,7 @@ public class BrandRepositoryTest {
         Page<BrandFormDto> brands = brandRepository.findByBrandNmContaining(brandNmContaining, pageable).map(BrandFormDto::of);
 
         // 결과 검증
-        assertThat(brands.getContent()).hasSize(1); 
+        assertThat(brands.getContent()).hasSize(1);
         assertThat(brands.getContent().get(0).getBrandNm()).contains(brandNmContaining); // 첫 번째 브랜드 이름에 '테스트' 문자열이 포함되어 있는지 확인
     }
 

--- a/src/test/java/com/shoppingmall/project_shoppingmall/repository/BrandRepositoryTest.java
+++ b/src/test/java/com/shoppingmall/project_shoppingmall/repository/BrandRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.shoppingmall.project_shoppingmall.repository;
+
+import com.shoppingmall.project_shoppingmall.domain.*;
+import com.shoppingmall.project_shoppingmall.dto.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.data.domain.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class BrandRepositoryTest {
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Test
+    public void testFindByBrandNmContaining() {
+        String brandNmContaining = "brand1";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<BrandFormDto> brands = brandRepository.findByBrandNmContaining(brandNmContaining, pageable).map(BrandFormDto::of);
+
+        // 결과 검증
+        assertThat(brands.getContent()).hasSize(1); 
+        assertThat(brands.getContent().get(0).getBrandNm()).contains(brandNmContaining); // 첫 번째 브랜드 이름에 '테스트' 문자열이 포함되어 있는지 확인
+    }
+
+    @Test
+    public void testFindByBrandCodeContaining() {
+        String brandCodeContaining = "B0000001";
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<BrandFormDto> brands = brandRepository.findByBrandCodeContaining(brandCodeContaining, pageable).map(BrandFormDto::of);
+
+        // 결과 검증
+        assertThat(brands).hasSize(1);
+        assertThat(brands.getContent().get(0).getBrandCode()).contains(brandCodeContaining);
+
+    }
+
+
+}

--- a/src/test/java/com/shoppingmall/project_shoppingmall/service/PaginationServiceTest.java
+++ b/src/test/java/com/shoppingmall/project_shoppingmall/service/PaginationServiceTest.java
@@ -1,0 +1,65 @@
+package com.shoppingmall.project_shoppingmall.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.context.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("페이지네이션 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class)
+class PaginationServiceTest {
+
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService paginationService){
+        this.sut = paginationService;
+    }
+
+    @DisplayName("current pageNumber,total pageNumber를 주면 page bar 리스트를 만들어준다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] 현재 페이지: {0}, 총 페이지: {1} => {2}")
+    void givenCurrentPageNumberAndToTalPages_whenCalculating_thenReturnPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expected){
+        // Given
+
+        // When
+        List<Integer> actual = sut.getPaginationBarNumbers(currentPageNumber,totalPages);
+
+        // Then
+        //assertj의 assertThat
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> givenCurrentPageNumberAndToTalPages_whenCalculating_thenReturnPaginationBarNumbers(){
+        return Stream.of(
+                arguments(0, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(1, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(2, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(3, 13, List.of(1, 2, 3, 4, 5)),
+                arguments(4, 13, List.of(2, 3, 4, 5, 6)),
+                arguments(5, 13, List.of(3, 4, 5, 6, 7)),
+                arguments(6, 13, List.of(4, 5, 6, 7, 8)),
+                arguments(10, 13, List.of(8, 9, 10, 11, 12)),
+                arguments(11, 13, List.of(9, 10, 11, 12)),
+                arguments(12, 13, List.of(10, 11, 12))
+        );
+    }
+
+    @DisplayName("현재 설정되어 있는 페이지네이션 바의 길이를 알려준다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsCurrentBarLength() {
+        // Given
+
+        // When
+        int barLength = sut.currentBarLength();
+
+        // Then
+        assertThat(barLength).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
오타로인한 버그 찾기때문에 힘들었다. 
브랜드 조회 브랜드명과,브랜드코드별로 조회 가능하다.

검색의 경우에도 쿼리파라미터를 이용해서 검색이 가능하게 했으며 사용여부에 따라 조건을 추가할수 있다. 

화살표 아이콘을 클릭하여 정렬할수있도록 함.

- id를 체크하지 않고 브랜드 삭제시에 오류를 출력하도록 기능 추가하였음. 
- pagination 링크부분에 500에러가 나서 확인 ,오타 수정하였음. 

This closes #33