### PR TITLE
#71-koyeb java설정을 위한 gitignore 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 
 # IntelliJ Cache and Output Cleanup files
 outputCleanup/
-*.properties
+#*.properties
 cache.properties
 
 # User-specific stuff

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
디폴트가 java21로 빌드되므로 실패되어 gitignore에 있던 .porperties를 제거하고 system.properties에 java11을 사용함을 명시하였음. 
This closes #71 